### PR TITLE
Fix for Inconsistencies in float/string vs int/string comparisons

### DIFF
--- a/src/buzz/buzztype.c
+++ b/src/buzz/buzztype.c
@@ -173,30 +173,9 @@ int buzzobj_cmp(const buzzobj_t a,
       if(a->f.value > b->f.value) return 1;
       return 0;
    }
-   /* String and other types */
+   /* Strings */
    if(a->o.type == BUZZTYPE_STRING && b->o.type == BUZZTYPE_STRING) {
       return buzzobj_strcmp(a->s.value.str, b->s.value.str);
-   }
-   if(a->o.type == BUZZTYPE_STRING && b->o.type == BUZZTYPE_INT) {
-      char str[30];
-      sprintf(str, "%d", b->i.value);
-      return buzzobj_strcmp(a->s.value.str, str);
-   }
-   if(a->o.type == BUZZTYPE_STRING && b->o.type == BUZZTYPE_FLOAT) {
-      char str[30];
-      sprintf(str, "%f", b->f.value);
-      return buzzobj_strcmp(a->s.value.str, str);
-   }
-
-   if(a->o.type == BUZZTYPE_INT && b->o.type == BUZZTYPE_STRING) {
-      char str[30];
-      sprintf(str, "%d", a->i.value);
-      return buzzobj_strcmp(str, b->s.value.str);
-   }
-   if(a->o.type == BUZZTYPE_FLOAT && b->o.type == BUZZTYPE_STRING) {
-      char str[30];
-      sprintf(str, "%f", a->f.value);
-      return buzzobj_strcmp(str, b->s.value.str);
    }
    /* Tables */
    if(a->o.type == BUZZTYPE_TABLE || b->o.type == BUZZTYPE_TABLE) {

--- a/src/testing/unittest/buzztype_test.cpp
+++ b/src/testing/unittest/buzztype_test.cpp
@@ -323,39 +323,34 @@ TEST(BuzzObjCompare, String) {
     EXPECT_EQ(buzzobj_cmp(buzzobj_new_string("A string"), buzzobj_new_string("A string")), 0);
     EXPECT_EQ(buzzobj_cmp(buzzobj_new_string("A string"), buzzobj_new_string("Buzz")), -1);
     EXPECT_EQ(buzzobj_cmp(buzzobj_new_string("Test"), buzzobj_new_string("Buzz")), 1);
-
-    // Tests for left string and right integer values
-    EXPECT_EQ(buzzobj_cmp(buzzobj_new_string("1"), buzzobj_new_int(1)), 0);
-    EXPECT_EQ(buzzobj_cmp(buzzobj_new_string("100"), buzzobj_new_int(42)), -1);
-    EXPECT_EQ(buzzobj_cmp(buzzobj_new_string("34abc"), buzzobj_new_int(12)), 1);
-
-    // Tests for left integer and right string values
-    EXPECT_EQ(buzzobj_cmp(buzzobj_new_int(-9), buzzobj_new_string("-9")), 0);
-    EXPECT_EQ(buzzobj_cmp(buzzobj_new_int(2), buzzobj_new_string("23")), -1);
-    EXPECT_EQ(buzzobj_cmp(buzzobj_new_int(99), buzzobj_new_string("8a")), 1);
-
-    // Tests for left string and right float values
-    EXPECT_EQ(buzzobj_cmp(buzzobj_new_string("1"), buzzobj_new_int(1)), 0);
-    EXPECT_EQ(buzzobj_cmp(buzzobj_new_string("100"), buzzobj_new_int(42)), -1);
-    EXPECT_EQ(buzzobj_cmp(buzzobj_new_string("34abc"), buzzobj_new_int(12)), 1);
-
-    // Tests for left float and right string values
-    EXPECT_EQ(buzzobj_cmp(buzzobj_new_float(-9.0f), buzzobj_new_string("-9.0")), 0);
-    EXPECT_EQ(buzzobj_cmp(buzzobj_new_float(2.5f), buzzobj_new_string("23")), -1);
-    EXPECT_EQ(buzzobj_cmp(buzzobj_new_float(99.9f), buzzobj_new_string("8a")), 1);
 }
 
 // Tests for `buzzobj_cmp` defined in <buzz/buzztype.h>
 // Test cases for comparisons with incompatible/invalid types.
 TEST(BuzzObjCompare, IncompatibleTypes) {
     const char* errorRegex = "^(\\[TODO\\] )(.*)(: Error for comparison between Buzz objects of types [0-9]+ and [0-9]+\n)$";
+    
+    /* Tests for strings and numeric types. Should die with clear error message */
+    // Tests for left string and right integer values
+    EXPECT_DEATH(buzzobj_cmp(buzzobj_new_string("1"), buzzobj_new_int(1)), errorRegex);
+    EXPECT_DEATH(buzzobj_cmp(buzzobj_new_string("100"), buzzobj_new_int(42)), errorRegex);
+    EXPECT_DEATH(buzzobj_cmp(buzzobj_new_string("34abc"), buzzobj_new_int(12)), errorRegex);
+    EXPECT_DEATH(buzzobj_cmp(buzzobj_new_int(-9), buzzobj_new_string("-9")), errorRegex);
+    EXPECT_DEATH(buzzobj_cmp(buzzobj_new_int(2), buzzobj_new_string("23")), errorRegex);
+    EXPECT_DEATH(buzzobj_cmp(buzzobj_new_int(99), buzzobj_new_string("8a")), errorRegex);
+    EXPECT_DEATH(buzzobj_cmp(buzzobj_new_string("1"), buzzobj_new_int(1)), errorRegex);
+    EXPECT_DEATH(buzzobj_cmp(buzzobj_new_string("100"), buzzobj_new_int(42)), errorRegex);
+    EXPECT_DEATH(buzzobj_cmp(buzzobj_new_string("34abc"), buzzobj_new_int(12)), errorRegex);
+    EXPECT_DEATH(buzzobj_cmp(buzzobj_new_float(-9.0f), buzzobj_new_string("-9.0")), errorRegex);
+    EXPECT_DEATH(buzzobj_cmp(buzzobj_new_float(2.5f), buzzobj_new_string("23")), errorRegex);
+    EXPECT_DEATH(buzzobj_cmp(buzzobj_new_float(99.9f), buzzobj_new_string("8a")), errorRegex);
 
-    // Tests for closures, should die with clear error message
+    /* Tests for closures, should die with clear error message */
     EXPECT_DEATH(buzzobj_cmp(buzzobj_new(BUZZTYPE_CLOSURE), buzzobj_new(BUZZTYPE_CLOSURE)), errorRegex);
     EXPECT_DEATH(buzzobj_cmp(buzzobj_new(BUZZTYPE_CLOSURE), buzzobj_new_int(1)), errorRegex);
     EXPECT_DEATH(buzzobj_cmp(buzzobj_new_string("3abc0"), buzzobj_new(BUZZTYPE_CLOSURE)), errorRegex);
 
-    // Tests for comparison between userdata and any other type
+    /* Tests for comparison between userdata and any other type */
     EXPECT_DEATH(buzzobj_cmp(buzzobj_new_string("This is a test string."), buzzobj_new(BUZZTYPE_USERDATA)), errorRegex);
     EXPECT_DEATH(buzzobj_cmp(buzzobj_new_float(87.2f), buzzobj_new(BUZZTYPE_USERDATA)), errorRegex);
     // This comparison might be invalid (userdata should only be compared between themselves) 


### PR DESCRIPTION
To fix issue #104 , comparisons between strings and floats as well as between strings and ints were disallowed (removed) 
Tests were adjusted accordingly.